### PR TITLE
[settling_probe] Fix PROBE and PROBE_ACCURACY commands

### DIFF
--- a/settling_probe/README.md
+++ b/settling_probe/README.md
@@ -27,7 +27,7 @@ the `[probe]` section:
 #   Screw Tilt, etc.)
 ```
 
-The module also augments the `PROBE`, `PROBE_ACCURACY`, and `PROBE_CALIBRATE`
-commands with an extra parameter - `SETTLING_SAMPLE` - which can be used to
-control whether the commands perform a settling sample independently from the
+The module also augments the `PROBE` and `PROBE_ACCURACY` commands with an
+extra parameter - `SETTLING_SAMPLE` - which can be used to control whether
+the commands perform a settling sample independently from the
 `settling_sample` setting.


### PR DESCRIPTION
Commit 4dc2641a65a6 ("[settling_probe] Update settling_probe extension after Klipper probe changes") reworked the settling_probe extenstion based on Klipper's changes to the probe module.

As part of the rework, how the PROBE and PROBE_ACCURACY commands were handled changed. Unfortunately, that introduced a bug (issue #11) that would cause a Klipper crash.

This commit fixes this bug (#11) by removing the custom command helper class, which is not actually needed. All of the work is done by the probe session helper. So, that is where the settling sample should be handled, anyway.

A side effect of this is that the PROBE_CALIBRATE command no longer accepts the SETTLING_SAMPLE parameter. Arguably, it should have never accepted it since PROBE_CALIBRATE works completely differently.